### PR TITLE
Track order history and show additional order details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /__pycache__/*
 /tesla_orders.json
 /tesla_tokens.json
+/tesla_order_history.json
+

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Then you can run the script by running:
 python3 tesla_order_status.py
 ```
 
+The script stores the latest order information in `tesla_orders.json` and keeps a change log in `tesla_order_history.json`. Each time a difference is detected (for example a VIN assignment), the change is appended to the history file and displayed after the current status.
+
+During the summary, additional details such as the delivery center and financing partner are shown to provide more context.
+
 ## Preview
 
 #### Main information


### PR DESCRIPTION
## Summary
- keep a separate `tesla_order_history.json` and append changes with timestamps whenever order data changes
- display delivery center and financing partner in the order summary
- document history tracking and extra details in README
