### PR TITLE
Added safe fallback to print auth URL

### DIFF
--- a/app/utils/auth.py
+++ b/app/utils/auth.py
@@ -54,7 +54,13 @@ def _get_auth_code(code_challenge: str):
     if input(color_text(t("Proceed to open the login page? (y/n): "), '93')).lower() != 'y':
         print(color_text(t("Authentication cancelled."), '91'))
         sys.exit(0)
-    webbrowser.open(auth_url)
+    try:
+        if not webbrowser.open(auth_url):
+            print(color_text(t("No GUI detected. Open this URL manually:"), 91))
+            print(f"{auth_url}")
+    except Exception:
+        print(color_text(t("No GUI detected. Open this URL manually:"), 91))
+        print(f"{auth_url}")
     redirected_url = input(color_text(t("Please enter the redirected URL here: "), '93'))
     parsed_url = urllib.parse.urlparse(redirected_url)
     params = urllib.parse.parse_qs(parsed_url.query)


### PR DESCRIPTION
**Rationale:**
Script is intended to be run in the environment where desktop apps cannot be run. In many cases it may mean headless/server environment, especially the script is used in --status mode for automations.

**Solution:**
Added safe fallback to print auth URL in case the script is run in headless/server environment. `webbrowser.open` will not work.

**Tested:**
Ubuntu Server (headless) and MacOS (browser)