### PR TITLE
Show wheels in  `Order Details`

### DIFF
--- a/app/utils/orders.py
+++ b/app/utils/orders.py
@@ -292,7 +292,8 @@ def _render_share_output(detailed_orders):
         print(color_text(header, '94'))
 
 
-        model = paint = interior = "unknown"
+        model = paint = interior = wheels = "unknown"
+        wheel_sizes = set()
 
         decoded_options = decode_option_codes(order.get('mktOptions', ''))
         if decoded_options:
@@ -301,7 +302,14 @@ def _render_share_output(detailed_orders):
                 category = entry.get('category')
                 cleaned_description = description.strip()
 
-                if category == 'paints' and cleaned_description:
+                if cleaned_description and code.startswith("W"):
+                    size_match = re.search(r"\b(\d{2})\s*\"", cleaned_description)
+                    if size_match:
+                        wheel_sizes.add(f'{size_match.group(1)}"')
+
+                if category == "wheels" and cleaned_description:
+                    wheels = cleaned_description
+                elif category == 'paints' and cleaned_description:
                     paint = cleaned_description.replace('Metallic', '').replace('Multi-Coat','').strip()
                 elif category in {'interiors', 'interior', 'seats'} and cleaned_description:
                     interior = cleaned_description
@@ -310,6 +318,8 @@ def _render_share_output(detailed_orders):
                         paint = cleaned_description
                     if interior == "unknown" and code.startswith(('IP', 'IN', 'IW', 'IX', 'IY')):
                         interior = cleaned_description
+                    if wheels == "unknown" and code.startswith('W'):
+                        wheels = cleaned_description
 
                 if category in {'models', 'model'} or ('Model' in cleaned_description and len(cleaned_description) > 10):
                     match = re.match(r'(Model [YSX3])(?:.*?((?:AWD|RWD) (?:LR|SR|P)))?.*?$', cleaned_description)
@@ -321,8 +331,13 @@ def _render_share_output(detailed_orders):
                         else:
                             model = cleaned_description.strip()
 
+        if wheel_sizes:
+            wheels = "/".join(sorted(wheel_sizes, key=lambda x: int(x.rstrip('"'))))
+
         if model and paint and interior:
             msg = f"{model} / {paint} / {interior}"
+            if wheels != "unknown":
+                msg = f"{msg} / {wheels}"
             print(f"- {msg}")
 
         if scheduling.get('deliveryAddressTitle'):


### PR DESCRIPTION
Hi @chrisi51,

to make support in the TFF forum easier, I’ve added the wheels to the Order details (shared mode) based on the configuration pattern starting with `W`. I also included an option for winter tires, so both sizes are shown when they differ.

If you prefer, we can also show only the summer tires. I don’t have a strong opinion either 🙂

Example Output:
```yaml
Order Details:
- Model Y - AWD LR / Quicksilver / Black / 19"
- Tesla Delivery & Used Car Center Stuttgart Holzgerlingen
```

Thx